### PR TITLE
Fix bug when entity term is not remove

### DIFF
--- a/src/behaviors/PropertyTermBehavior.php
+++ b/src/behaviors/PropertyTermBehavior.php
@@ -59,9 +59,9 @@ class PropertyTermBehavior extends BaseTermBehavior
 
     public function delPropertyTerm($type, $name, $value)
     {
-        $entity = $this->getPropertyTerms($type)->where([Taxonomy::tableName() . '.name' => $name])->andWhere([Term::tableName() . '.name' => $value])->all();
+        $entity = $this->getPropertyTerms($type)->where([Taxonomy::tableName() . '.name' => $name])->andWhere([Term::tableName() . '.name' => $value])->one();
 
-        if (is_object($entity)) {
+        if ($entity != false) {
             return $entity->delete();
         }
 


### PR DESCRIPTION
Fix this function does not delete property term of an entity due to `$entity` is always return an array.